### PR TITLE
Publish rgapi releases to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
       - uses: actions/download-artifact@v8
         with:
           path: dist

--- a/DEV.md
+++ b/DEV.md
@@ -34,7 +34,7 @@ Release flow is: release first, then bump - `ship-release` does both.
 2. Confirm the release version in `Cargo.toml` (`[package].version`).
 3. Run `ship-release`. It tags `v<version>`, pushes branch and tag (CI builds and publishes), then bumps `Cargo.toml`, refreshes the editable install, and pushes the bump without a tag.
 
-The GitHub workflow builds wheels for Python 3.10-3.13 on Linux and macOS and publishes artifacts to GitHub Releases and PyPI when a `v*` tag is pushed.
+The GitHub workflow builds wheels for Python 3.10-3.13 on Linux and macOS and publishes the Rust crate, GitHub release artifacts, and PyPI package when a `v*` tag is pushed.
 
 ## Design notes
 


### PR DESCRIPTION
Add crates.io trusted publishing to the existing tag workflow so Rust
consumers can depend on the same rgapi versions published to GitHub and
PyPI. This unblocks Rustygate from replacing its workspace-only path
dependency with a registry version.

See “Release” in DEV.md for the publishing contract.