### PR TITLE
Add a CLI for notebook-aware search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: PyO3/maturin-action@v1
         with:
-          args: --release --out dist -i python3.10 -i python3.11 -i python3.12 -i python3.13
+          args: --profile dist --out dist -i python3.10 -i python3.11 -i python3.12 -i python3.13
           manylinux: auto
       - uses: actions/upload-artifact@v7
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,18 @@ extension-module = ["python", "pyo3/extension-module"]
 too_many_arguments = "allow"
 
 [profile.release]
+lto = false
+codegen-units = 16
+
+[profile.release.package.rgapi]
+incremental = true
+
+[profile.dist]
+inherits = "release"
+lto = true
+incremental = false
+codegen-units = 1
 strip = true
+
+[profile.dist.package.rgapi]
+incremental = false

--- a/DEV.md
+++ b/DEV.md
@@ -9,7 +9,7 @@ src/walk.rs       ignore/globset/grep-regex-backed path walking and filtering
 src/search.rs     grep-regex/grep-searcher-backed searching
 src/block.rs      blank-line-delimited block grouping, matching, and block context
 src/python.rs     PyO3 classes and private core functions
-python/rgapi/     public Python wrappers over `rgapi._core`
+python/rgapi/     public Python wrappers over `rgapi._core`, plus the `rgapi-nbrg` CLI
 tests/            pytest coverage for the Python API
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ matches      list of SearchLine rows for the matched lines within the cell
 
 Notebook walking, parsing, and matching all happen in parallel in Rust, in the same pass as the file walk. Parsing uses a lean model that reads only each cell's `id`, `cell_type`, and `source` and skips outputs and metadata, so large embedded outputs (images, plots) are never materialized. `search_nb(pattern, path, ...)` searches a single notebook file the same way.
 
+`rgapi-nbrg` exposes notebook search without requiring a Python kernel:
+
+```bash
+rgapi-nbrg 'read_csv' .
+rgapi-nbrg 'read_csv' . --cell-context 1
+rgapi-nbrg 'read_csv' nbs --glob '*.ipynb' --max-results 20
+```
+
+Run `rgapi-nbrg --help` for its discovery, matching, and output options.
+
 ## Async
 
 `fda`, `rga`, and `nbrga` are awaitable twins of `fd`, `rg`, and `nbrg`, and `fda_iter`, `rga_iter` and `nbrga_iter` are async generators that yield rows as the search finds them. All take the same arguments and return the same types as their sync counterparts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ rgapi = "rgapi.skill"
 [project.entry-points.fastaudit_safe_native]
 rgapi = "rgapi"
 
+[project.scripts]
+rgapi-nbrg = "rgapi._cli:nbrg_cli"
+
 [tool.maturin]
 features = ["extension-module"]
 python-source = "python"

--- a/python/rgapi/_cli.py
+++ b/python/rgapi/_cli.py
@@ -1,0 +1,28 @@
+"Command-line access to notebook-aware search."
+
+from fastcore.script import call_parse
+from . import nbrg
+
+
+@call_parse(pos=['root'])
+def nbrg_cli(
+    pattern:str, # Regex pattern to search for
+    root:str='.', # File or directory to search
+    cell_context:int=0, # Neighbouring cells to include before and after matches
+    multiline:bool=False, # Allow matches across lines within a cell?
+    smart_case:bool=False, # Use case-sensitive matching when the pattern contains uppercase?
+    case:bool=False, # Force case-sensitive matching?
+    paths:bool=False, # Return only matching notebook paths?
+    count:bool=False, # Return the number of matching cells?
+    max_results:int=None, # Maximum matching cells to return
+    maxlen:int=180, # Maximum source characters displayed per cell
+    glob:str=None, # Glob selecting notebook paths
+    exclude:str=None, # Glob excluding notebook paths
+    hidden:bool=False, # Search hidden files and directories?
+    max_depth:int=None, # Maximum directory depth to search
+    timeout_ms:int=None, # Stop searching after this many milliseconds
+):
+    "Search notebook cell sources and report stable cell IDs."
+    print(nbrg(pattern, root, cell_context=cell_context, multiline=multiline, smart_case=smart_case,
+        case_sensitive=True if case else None, paths=paths, count=count, max_results=max_results, maxlen=maxlen,
+        glob=glob, exclude=exclude, hidden=hidden, max_depth=max_depth, timeout_ms=timeout_ms))


### PR DESCRIPTION
`rgapi-nbrg` provides notebook-cell search, stable IDs, context, filtering,
and bounded results without requiring a Python kernel. The Rust profiles
keep local release builds incremental while CI uses the optimized `dist`
profile. See “Notebook search” in the README.