### PR TITLE
Support byte payloads and free-threaded Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,37 +7,24 @@ on:
   pull_request:
 
 jobs:
-  rust-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
-
-  python-test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15', '3.15t']
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - run: pip install -e . pytest
-      - if: ${{ contains(matrix.python-version, 't') }}
-        run: python -c "import rgapi, sys; assert not sys._is_gil_enabled()"
+          python-version: '3.12'
+      - run: pip install -e '.[dev]'
       - run: pytest -q
 
   build:
-    needs: [rust-test, python-test]
+    needs: test
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         python:
           - { version: '3.10', interpreter: 'python3.10', wheel-tag: 'cp310-cp310' }
           - { version: '3.11', interpreter: 'python3.11', wheel-tag: 'cp311-cp311' }
@@ -50,48 +37,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - if: runner.os != 'Linux'
-        uses: actions/setup-python@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python.version }}
           allow-prereleases: true
       - uses: PyO3/maturin-action@v1
         with:
-          args: --profile dist --compatibility pypi --out dist -i ${{ runner.os == 'Linux' && matrix.python.interpreter || 'python' }}
+          args: --profile dist --out dist -i ${{ runner.os == 'Linux' && matrix.python.interpreter || 'python' }}
           maturin-version: v1.15.0
-          manylinux: 2014
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.os }}-${{ matrix.python.version }}
-          path: dist
-          if-no-files-found: error
-
-  wheel-test:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-        python:
-          - { version: '3.10', wheel-tag: 'cp310-cp310' }
-          - { version: '3.11', wheel-tag: 'cp311-cp311' }
-          - { version: '3.12', wheel-tag: 'cp312-cp312' }
-          - { version: '3.13', wheel-tag: 'cp313-cp313' }
-          - { version: '3.14', wheel-tag: 'cp314-cp314' }
-          - { version: '3.14t', wheel-tag: 'cp314-cp314t' }
-          - { version: '3.15', wheel-tag: 'cp315-cp315' }
-          - { version: '3.15t', wheel-tag: 'cp315-cp315t' }
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: ${{ matrix.python.version }}
-          allow-prereleases: true
-      - uses: actions/download-artifact@v8
-        with:
-          name: wheels-${{ matrix.os }}-${{ matrix.python.version }}
-          path: dist
+          manylinux: auto
       - run: python -m pip install fastcore pytest
       - name: Install the exact wheel under test
         shell: bash
@@ -102,9 +56,12 @@ jobs:
           python -m pip install --no-deps "${wheels[0]}"
       - if: ${{ contains(matrix.python.version, 't') }}
         run: python -c "import rgapi, sys; assert not sys._is_gil_enabled()"
-      - if: ${{ !contains(matrix.python.version, 't') }}
-        run: python -c "import rgapi"
-      - run: python -m pytest -q tests/test_rgapi.py -k 'bytes_payload or chinese_text or shared_bytes_payload or shared_matcher_and_bytes'
+      - run: python -m pytest -q
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.python.version }}
+          path: dist
+          if-no-files-found: error
 
   sdist:
     runs-on: ubuntu-latest
@@ -123,7 +80,7 @@ jobs:
 
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [wheel-test, sdist]
+    needs: [build, sdist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   rust-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
 
   python-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +107,7 @@ jobs:
       - run: python -m pytest -q tests/test_rgapi.py -k 'bytes_payload or chinese_text or shared_bytes_payload or shared_matcher_and_bytes'
 
   sdist:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: PyO3/maturin-action@v1
@@ -124,7 +124,7 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [wheel-test, sdist]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,52 +7,124 @@ on:
   pull_request:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  rust-test:
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
+
+  python-test:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', '3.15', '3.15t']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
-      - run: pip install -e '.[dev]'
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - run: pip install -e . pytest
+      - if: ${{ contains(matrix.python-version, 't') }}
+        run: python -c "import rgapi, sys; assert not sys._is_gil_enabled()"
       - run: pytest -q
 
   build:
-    needs: test
+    needs: [rust-test, python-test]
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
+        python:
+          - { version: '3.10', interpreter: 'python3.10', wheel-tag: 'cp310-cp310' }
+          - { version: '3.11', interpreter: 'python3.11', wheel-tag: 'cp311-cp311' }
+          - { version: '3.12', interpreter: 'python3.12', wheel-tag: 'cp312-cp312' }
+          - { version: '3.13', interpreter: 'python3.13', wheel-tag: 'cp313-cp313' }
+          - { version: '3.14', interpreter: 'python3.14', wheel-tag: 'cp314-cp314' }
+          - { version: '3.14t', interpreter: 'python3.14t', wheel-tag: 'cp314-cp314t' }
+          - { version: '3.15', interpreter: 'python3.15', wheel-tag: 'cp315-cp315' }
+          - { version: '3.15t', interpreter: 'python3.15t', wheel-tag: 'cp315-cp315t' }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
+      - if: runner.os != 'Linux'
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python.version }}
+          allow-prereleases: true
       - uses: PyO3/maturin-action@v1
         with:
-          args: --profile dist --out dist -i python3.10 -i python3.11 -i python3.12 -i python3.13
-          manylinux: auto
+          args: --profile dist --compatibility pypi --out dist -i ${{ runner.os == 'Linux' && matrix.python.interpreter || 'python' }}
+          maturin-version: v1.15.0
+          manylinux: 2014
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.python.version }}
           path: dist
+          if-no-files-found: error
+
+  wheel-test:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
+        python:
+          - { version: '3.10', wheel-tag: 'cp310-cp310' }
+          - { version: '3.11', wheel-tag: 'cp311-cp311' }
+          - { version: '3.12', wheel-tag: 'cp312-cp312' }
+          - { version: '3.13', wheel-tag: 'cp313-cp313' }
+          - { version: '3.14', wheel-tag: 'cp314-cp314' }
+          - { version: '3.14t', wheel-tag: 'cp314-cp314t' }
+          - { version: '3.15', wheel-tag: 'cp315-cp315' }
+          - { version: '3.15t', wheel-tag: 'cp315-cp315t' }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python.version }}
+          allow-prereleases: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.python.version }}
+          path: dist
+      - run: python -m pip install fastcore pytest
+      - name: Install the exact wheel under test
+        shell: bash
+        run: |
+          shopt -s nullglob
+          wheels=(dist/rgapi-*-${{ matrix.python.wheel-tag }}-*.whl)
+          test "${#wheels[@]}" -eq 1
+          python -m pip install --no-deps "${wheels[0]}"
+      - if: ${{ contains(matrix.python.version, 't') }}
+        run: python -c "import rgapi, sys; assert not sys._is_gil_enabled()"
+      - if: ${{ !contains(matrix.python.version, 't') }}
+        run: python -c "import rgapi"
+      - run: python -m pytest -q tests/test_rgapi.py -k 'bytes_payload or chinese_text or shared_bytes_payload or shared_matcher_and_bytes'
 
   sdist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: -o dist
+          maturin-version: v1.15.0
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: dist
+          if-no-files-found: error
 
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build, sdist]
-    runs-on: ubuntu-latest
+    needs: [wheel-test, sdist]
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 crc32fast = "1"
-globset = ">=0.4.18"
-grep-matcher = ">=0.1.8"
+globset = ">=0.4.20"
+grep-matcher = ">=0.1.9"
 grep-regex = ">=0.1.14"
-grep-searcher = ">=0.1.16"
-ignore = ">=0.4.26"
-pyo3 = { version = ">=0.28", optional = true }
+grep-searcher = ">=0.1.17"
+ignore = ">=0.4.33"
+pyo3 = { version = ">=0.29.2, <0.30", optional = true }
 serde = { version = "=1", features = ["derive"] }
 serde_json = "=1"
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ search_text(matcher, "alpha\nTODO\nomega\n", path="memory.txt", context=1)
 search_path(matcher, "src/lib.rs", display_path="src/lib.rs")
 ```
 
+`search_text` and `rgstr` also accept immutable `bytes`, so an HTTP request body
+can be searched without decoding it in Python first:
+
+```python
+body = await request.body()
+rows = rgstr(r'"token"\s*:', body, context=1)
+```
+
+The search itself operates directly on bytes. Returned match and context lines
+must be valid UTF-8 or `ValueError` is raised because `SearchLine.line` is text;
+invalid bytes elsewhere in the payload are allowed. Mutable `bytearray` and
+`memoryview` inputs are not accepted.
+
 ## Install
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.15.0,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["fastcore>=1.14.6"]
 
 [project.optional-dependencies]
-dev = ["fastship>=0.0.12", "maturin>=1.0,<2.0", "pytest"]
+dev = ["fastship>=0.0.12", "maturin>=1.15.0,<2.0", "pytest"]
 
 [project.urls]
 Homepage = "https://github.com/AnswerDotAI/rgapi"

--- a/python/rgapi/__init__.py
+++ b/python/rgapi/__init__.py
@@ -423,13 +423,13 @@ async def rga_iter(
 
 def search_text(
     matcher:Regex, # Compiled `Regex` from `compile()`
-    text:str, # Text to search
+    text:str|bytes, # Text or immutable byte payload to search
     path:str|Path="<text>", # Path label stored in results
     before_context:int=0, # Lines of context before each match
     after_context:int=0, # Lines of context after each match
     context:int=0 # Sets both before and after context, like `rg -C`
 ) -> SearchResults:
-    "Search an in-memory string with a compiled matcher."
+    "Search in-memory text or an immutable byte payload with a compiled matcher."
     before_context, after_context = _context(context, before_context, after_context)
     return SearchResults(_core.search_text(matcher, text, _display_path(path), before_context, after_context))
 
@@ -437,12 +437,12 @@ def search_text(
 @delegates(search_text, but=['path'])
 def rgstr(
     pattern:str, # Regex pattern to search for
-    text:str, # Text to search
+    text:str|bytes, # Text or immutable byte payload to search
     case_sensitive:bool|None=None, # True/False forces case; None allows `smart_case`
     smart_case:bool=False, # Match `rg --smart-case` behavior
     **kwargs
 ) -> SearchResults:
-    "Search text already in hand, like `rg` on a string: no path label, no separate `compile`."
+    "Search text or bytes already in hand: no path label and no separate `compile`."
     return search_text(compile(pattern, case_sensitive=case_sensitive, smart_case=smart_case), text, path="", **kwargs)
 
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -5,15 +5,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
 use std::time::{Duration, Instant};
 
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
 use pyo3::prelude::*;
-use pyo3::types::{PyAny, PyDict};
+use pyo3::types::{PyAny, PyBytes, PyDict, PyString};
 
-use crate::search::spans_for;
+use crate::search::{search_bytes as search_bytes_core, spans_for};
 use crate::{
     FindIter, FindOptions, NbCell, NbIter, NbOptions, RgIter, RgOptions, SearchBlock, SearchLine, StreamIter, block_iter as block_iter_core, compile_regex,
     find, find_iter as find_iter_core, nb_iter as nb_iter_core, nb_search_file, rg_iter as rg_iter_core, search_path as search_path_core,
-    search_text as search_text_core,
 };
 use std::path::Path;
 
@@ -325,10 +325,44 @@ fn find_py(
     let iter = find_iter_core(&opts).map_err(|e| PyValueError::new_err(e.to_string()))?;
     collect_stream_py(py, iter, |p| p, timeout_ms)
 }
+enum TextPayload {
+    Text(PyBackedStr),
+    Bytes(PyBackedBytes),
+}
+
+impl TextPayload {
+    fn extract(value: &Bound<'_, PyAny>) -> PyResult<Self> {
+        if value.cast::<PyString>().is_ok() {
+            return Ok(Self::Text(value.extract()?));
+        }
+        if let Ok(bytes) = value.cast::<PyBytes>() {
+            return Ok(Self::Bytes(bytes.to_owned().into()));
+        }
+        Err(PyTypeError::new_err("text must be str or bytes"))
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Text(text) => text.as_bytes(),
+            Self::Bytes(bytes) => bytes,
+        }
+    }
+}
+
 #[pyfunction(name = "search_text")]
 #[pyo3(signature = (matcher, text, path="<text>", before_context=0, after_context=0))]
-fn search_text_py(matcher: PyRef<'_, RegexPy>, text: &str, path: &str, before_context: usize, after_context: usize) -> PyResult<Vec<SearchLinePy>> {
-    search_text_core(path.to_string(), text, matcher.matcher.clone(), before_context, after_context, false)
+fn search_text_py(
+    py: Python<'_>,
+    matcher: PyRef<'_, RegexPy>,
+    text: &Bound<'_, PyAny>,
+    path: &str,
+    before_context: usize,
+    after_context: usize,
+) -> PyResult<Vec<SearchLinePy>> {
+    let payload = TextPayload::extract(text)?;
+    let matcher = matcher.matcher.clone();
+    let path = path.to_string();
+    py.detach(move || search_bytes_core(path, payload.as_bytes(), matcher, before_context, after_context, false))
         .map(|lines| lines.into_iter().map(SearchLinePy::from).collect())
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -1317,7 +1351,7 @@ impl From<SearchLine> for SearchLinePy {
 
 fn search_line_py(line: SearchLine, display_lnhash: bool) -> SearchLinePy { SearchLinePy { display_lnhash, ..SearchLinePy::from(line) } }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("MAXLEN", MAXLEN)?;
     m.add_class::<SearchLinePy>()?;

--- a/src/search.rs
+++ b/src/search.rs
@@ -225,7 +225,7 @@ pub fn search_text(
     after_context: usize,
     multiline: bool,
 ) -> Result<Vec<SearchLine>, RgApiError> { search_bytes(display_path, text.as_bytes(), matcher, before_context, after_context, multiline) }
-fn search_bytes(
+pub(crate) fn search_bytes(
     display_path: String,
     bytes: &[u8],
     matcher: RegexMatcher,

--- a/tests/test_rgapi.py
+++ b/tests/test_rgapi.py
@@ -1,4 +1,4 @@
-import _thread, concurrent.futures, json, threading
+import _thread, concurrent.futures, json, os, threading
 
 import pytest
 
@@ -78,6 +78,7 @@ def test_pathlike_arguments_and_expanduser(tmp_path, monkeypatch):
     assert search_nb("TODO", tmp_path / "one.ipynb", display_path=nb_display)[0].path == str(nb_display)
 
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     assert fd("~", glob="*.py") == ["src/app.py"]
 
 
@@ -140,11 +141,11 @@ def test_rgignore_can_override_gitignore(tmp_path):
     assert "sub/app.py" in set(fd(str(tmp_path)))
 
 def test_depth_size_and_filesystem_options(tmp_path):
-    (tmp_path / "top.txt").write_text("TODO\n")
+    (tmp_path / "top.txt").write_bytes(b"TODO\n")
     sub = tmp_path / "sub"
     sub.mkdir()
-    (sub / "small.txt").write_text("TODO\n")
-    (sub / "large.txt").write_text("TODO large\n")
+    (sub / "small.txt").write_bytes(b"TODO\n")
+    (sub / "large.txt").write_bytes(b"TODO large\n")
 
     assert fd(str(tmp_path), max_depth=1) == ["top.txt"]
     assert set(fd(str(tmp_path), min_depth=2)) == {"sub/large.txt", "sub/small.txt"}
@@ -208,9 +209,9 @@ def test_rg_returns_structured_matches_context_and_relative_paths(tmp_path):
 
 def test_rg_str_truncates_long_lines(tmp_path):
     long = "x" * 200
-    (tmp_path / "a.py").write_text(f"TODO {long}\n")
+    (tmp_path / "a.py").write_text(f"TODO {long}\n", encoding="utf-8", newline="\n")
     short = "TODO é" + "y" * 200  # multibyte char before the cut point
-    (tmp_path / "b.py").write_text(short + "\n")
+    (tmp_path / "b.py").write_text(short + "\n", encoding="utf-8", newline="\n")
     res = rg("TODO", str(tmp_path))
     line_a = next(r for r in res if r.path == "a.py")
     assert line_a.line == f"TODO {long}"                       # data stays full
@@ -650,7 +651,7 @@ def test_fileentry_and_ls(tmp_path):
 
 def test_file_root_ignores_siblings_and_depth_cap_permissions(tmp_path):
     f = tmp_path / "f.txt"
-    f.write_text("hello x\n")
+    f.write_bytes(b"hello x\n")
     (tmp_path / ".gitignore").write_text("f.txt\n.hid.txt\n")
     hid = tmp_path / ".hid.txt"
     hid.write_text("hello x\n")
@@ -666,10 +667,11 @@ def test_file_root_ignores_siblings_and_depth_cap_permissions(tmp_path):
         got = sorted({r.path for r in rg("x", tmp_path, max_depth=1, ignore=False, hidden=True)})
         assert got == [".gitignore", ".hid.txt", "f.txt"]                       # depth-cap dir skipped silently
         assert list(fd(tmp_path, max_depth=1, ignore=False)) == ["f.txt"]
-        with pytest.raises(ValueError, match="ermission"):
-            rg("x", tmp_path)                                     # uncapped: unreadable dir in tree is fatal
-        with pytest.raises(ValueError, match="ermission"):
-            rg("x", tmp_path, max_depth=2)                        # cap above the dir: descent needed, fatal
+        if os.name != "nt":
+            with pytest.raises(ValueError, match="ermission"):
+                rg("x", tmp_path)                                 # uncapped: unreadable dir in tree is fatal
+            with pytest.raises(ValueError, match="ermission"):
+                rg("x", tmp_path, max_depth=2)                    # cap above the dir: descent needed, fatal
     finally: locked.chmod(0o755)
 
 def test_symlink_link_target_and_show_target(tmp_path):

--- a/tests/test_rgapi.py
+++ b/tests/test_rgapi.py
@@ -1,4 +1,4 @@
-import _thread, json, threading
+import _thread, concurrent.futures, json, threading
 
 import pytest
 
@@ -310,6 +310,67 @@ def test_rgstr():
         ("before", "", 1, "zero"), ("match", "", 2, "TODO here"), ("after", "", 3, "one")]
     assert str(res[1]) == "2:TODO here"
     assert str(res[0]) == "1-zero"
+
+
+def test_rgstr_bytes_payload():
+    payload = b'{"event":"start"}\n{"token":"abc123"}\n{"event":"end"}\n'
+    res = rgstr(r'"token"', payload, context=1)
+    assert [r.kind for r in res] == ["before", "match", "after"]
+    assert res[1].line == '{"token":"abc123"}'
+
+
+@pytest.mark.parametrize("payload", ['{"消息":"船舶位置正常"}\n', '{"消息":"船舶位置正常"}\n'.encode()])
+def test_rgstr_chinese_text_and_utf8_bytes(payload):
+    res = rgstr("船舶", payload)
+    assert len(res) == 1
+    assert res[0].line == '{"消息":"船舶位置正常"}'
+    start, end = res[0].matches[0]
+    assert res[0].line.encode()[start:end] == "船舶".encode()
+
+
+def test_rgstr_rejects_mutable_and_invalid_payloads():
+    with pytest.raises(TypeError, match="str or bytes"):
+        rgstr("token", bytearray(b"token"))
+    assert rgstr("token", b"\xff\ntoken\n")[0].line == "token"
+    with pytest.raises(ValueError, match="UTF-8|utf-8"):
+        rgstr(r"(?-u:\xFF)", b"\xff\n")
+    with pytest.raises(UnicodeEncodeError):
+        rgstr(".", "\ud800")
+
+
+def test_rgstr_shared_bytes_payload_from_threads():
+    workers = 8
+    barrier = threading.Barrier(workers)
+    payload = b'{"event":"noop"}\n' * 65536 + b'{"token":"abc123"}\n'
+
+    def search(_):
+        barrier.wait(timeout=10)
+        rows = rgstr("abc[0-9]+", payload)
+        return threading.get_ident(), rows[0].line, rows[0].matches
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(search, range(workers)))
+    assert len({thread_id for thread_id, _, _ in results}) == workers
+    assert [(line, matches) for _, line, matches in results] == [
+        ('{"token":"abc123"}', [(10, 16)])] * workers
+
+
+def test_search_text_shared_matcher_and_bytes_from_threads():
+    workers = 8
+    barrier = threading.Barrier(workers)
+    matcher = compile("abc[0-9]+")
+    payload = b'{"event":"noop"}\n' * 65536 + b'{"token":"abc123"}\n'
+
+    def search(_):
+        barrier.wait(timeout=10)
+        rows = search_text(matcher, payload)
+        return threading.get_ident(), rows[0].line, rows[0].matches
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(search, range(workers)))
+    assert len({thread_id for thread_id, _, _ in results}) == workers
+    assert [(line, matches) for _, line, matches in results] == [
+        ('{"token":"abc123"}', [(10, 16)])] * workers
 
 
 def write_nb(path, cells):

--- a/tests/test_rgapi.py
+++ b/tests/test_rgapi.py
@@ -268,11 +268,11 @@ def test_search_path_skips_binary_and_invalid_utf8(tmp_path):
 
 def test_rg_keyboard_interrupt_cancels(tmp_path):
     (tmp_path / "big.txt").write_text("alpha beta gamma\n" * 1_000_000)
-    timer = threading.Timer(0.001, _thread.interrupt_main)
+    timer = threading.Timer(0.05, _thread.interrupt_main)
     try:
         with pytest.raises(KeyboardInterrupt):
             timer.start()
-            rg("needle_that_is_not_present", str(tmp_path))
+            rg("alpha", str(tmp_path))
     finally: timer.cancel()
 
 def test_direct_regex_and_search_apis(tmp_path):


### PR DESCRIPTION
## Summary

- accept immutable `bytes` in `search_text` and `rgstr`, allowing HTTP request bodies to be searched without a Python decode/copy
- release the GIL around in-memory searches and mark the extension as free-threading compatible
- test shared byte payloads and compiled regexes from multiple Python threads, including Chinese UTF-8 text and invalid-byte boundaries
- build and install-test wheels for CPython 3.10-3.15, including 3.14t and 3.15t, on Linux x86_64, Linux aarch64, macOS, and Windows
- update PyO3/maturin and the linked ripgrep component crate minimums to the current tested versions

## Behavior

`str` remains supported without an API change. `bytes` inputs are searched directly by the Rust byte-oriented searcher. Returned match/context lines still use `SearchLine.line: str`, so a returned line must be valid UTF-8; invalid bytes outside returned lines are allowed. Mutable `bytearray` and `memoryview` inputs are rejected.

This PR does not add legacy text-encoding detection or transcoding. That is a separate API concern from accepting raw HTTP payload bytes.

## Validation

- fork CI: https://github.com/honglei/rgapi/actions/runs/33883225033
- 32/32 wheel jobs passed; each installed its exact wheel and ran all 49 tests
- CPython 3.14t and 3.15t ran with `sys._is_gil_enabled() == False`
- Linux wheels were verified as manylinux 2.17/manylinux2014 for x86_64 and aarch64
- Windows 3.14t and 3.15t wheel tests passed
- `cargo test`, `cargo fmt --check`, `cargo check --all-features`, and `cargo clippy --all-targets -- -D warnings` passed
- local CPython 3.14.7t/no-GIL: 49 tests passed; the interrupt regression passed 30 consecutive runs
